### PR TITLE
add aria label, and role for accessebility

### DIFF
--- a/src/components/layouts/IconSvg.vue
+++ b/src/components/layouts/IconSvg.vue
@@ -27,14 +27,6 @@ export default {
       default: "mask",
       validator: (value) => ["mask", "image"].includes(value),
     },
-    label: {
-      type: String,
-      default: "",
-    },
-    isHidden: {
-      type: Boolean,
-      default: false,
-    },
   },
   computed: {
     computedStyle() {
@@ -67,10 +59,5 @@ export default {
 </script>
 
 <template>
-  <span
-    :style="computedStyle"
-    :aria-label="label"
-    :aria-hidden="isHidden"
-    role="img"
-  />
+  <span :style="computedStyle" role="img" />
 </template>

--- a/src/components/layouts/IconSvg.vue
+++ b/src/components/layouts/IconSvg.vue
@@ -27,6 +27,14 @@ export default {
       default: "mask",
       validator: (value) => ["mask", "image"].includes(value),
     },
+    label: {
+      type: String,
+      default: "",
+    },
+    isHidden: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     computedStyle() {
@@ -59,5 +67,10 @@ export default {
 </script>
 
 <template>
-  <span :style="computedStyle" aria-label="hidden" />
+  <span
+    :style="computedStyle"
+    :aria-label="label"
+    :aria-hidden="isHidden"
+    role="img"
+  />
 </template>

--- a/src/views/LoginPage/Index.vue
+++ b/src/views/LoginPage/Index.vue
@@ -27,11 +27,16 @@ export default {
           Selamat datang di
         </h1>
 
-        <div class="m-auto flex justify-center">
+        <div
+          class="m-auto flex justify-center"
+          aria-label="Digiteam Inventaris"
+          role="text"
+        >
           <IconSvg
             icon="/logo/logo-inventaris.svg"
             :width="450"
             :height="100"
+            is-hidden="true"
             mode="image"
           />
         </div>
@@ -45,6 +50,7 @@ export default {
             <IconSvg
               icon="/icons/key.svg"
               fill-color="white"
+              is-hidden="true"
               class="!m-auto !mr-2 !h-5 !w-5"
             />
 
@@ -56,12 +62,14 @@ export default {
         <IconSvg
           icon="/logo/diskominfo.png"
           mode="image"
+          is-hidden="true"
           class="!m-auto !h-[40px] !w-[90px] md:!m-0 md:!h-[50px] md:!w-[170px]"
         />
 
         <IconSvg
           icon="/logo/jds-logo.svg"
           mode="image"
+          is-hidden="true"
           class="!m-auto !h-[40px] !w-[90px] md:!m-0 md:!h-[50px] md:!w-[170px]"
         />
       </div>

--- a/src/views/layout/NavbarMenu.vue
+++ b/src/views/layout/NavbarMenu.vue
@@ -19,6 +19,8 @@ export default {
   >
     <button
       class="font-extrabold text-blue-900"
+      type="button"
+      aria-label="Menu"
       @click="getResponseToggleSidebar"
     >
       <IconSvg icon="/icons/burger-button.svg" class="!h-5 !w-5 !bg-gray-700" />

--- a/src/views/layout/Sidebar.vue
+++ b/src/views/layout/Sidebar.vue
@@ -10,6 +10,7 @@ export default {
           routerLinkName: "list-request",
           icon: "book.svg",
           nameRouter: "Permohonan",
+          label: "Daftar Permohonan",
         },
       ],
     };
@@ -23,7 +24,12 @@ export default {
       class="absolute inset-y-0 left-0 min-h-screen -translate-x-full space-y-6 bg-white p-5 px-2 py-4 pt-5 font-semibold text-gray-700 duration-200 ease-in-out md:relative md:h-full md:-translate-x-0"
       :class="showSidebar ? 'relative w-60 -translate-x-0' : 'w-24'"
     >
-      <a href="" class="flex items-center space-x-2 px-4">
+      <a
+        href=""
+        class="flex items-center space-x-2 px-4"
+        role="link"
+        aria-label="Daftar Permohonan"
+      >
         <IconSvg
           v-if="showSidebar"
           icon="/logo/logo-inventaris.svg"
@@ -44,6 +50,8 @@ export default {
       <nav v-for="(menu, index) in menuSidebar" :key="index">
         <router-link
           :to="{ name: menu.routerLinkName }"
+          role="link"
+          aria-label="Daftar Permohonan"
           class="group mt-2 flex items-center space-x-2 rounded-xl py-3 px-4 transition duration-500 ease-in-out hover:bg-blue-100"
         >
           <IconSvg

--- a/src/views/layout/Sidebar.vue
+++ b/src/views/layout/Sidebar.vue
@@ -27,7 +27,6 @@ export default {
       <a
         href=""
         class="flex items-center space-x-2 px-4"
-        role="link"
         aria-label="Daftar Permohonan"
       >
         <IconSvg
@@ -50,7 +49,6 @@ export default {
       <nav v-for="(menu, index) in menuSidebar" :key="index">
         <router-link
           :to="{ name: menu.routerLinkName }"
-          role="link"
           aria-label="Daftar Permohonan"
           class="group mt-2 flex items-center space-x-2 rounded-xl py-3 px-4 transition duration-500 ease-in-out hover:bg-blue-100"
         >


### PR DESCRIPTION
# OVERVIEW

## PREVIEW

### LOGIN PAGE

#### BEFORE
![accesibilty without role img](https://user-images.githubusercontent.com/58242304/209519679-fb960933-450a-45e7-8773-f4907c198f70.png)

#### AFTER 
![login light with aria](https://user-images.githubusercontent.com/58242304/209519702-53c60a65-1f46-4ae6-afe6-aafa4719f9be.png)


### DAFTAR PERMOHONAN 

### BEFORE
![halaman request page](https://user-images.githubusercontent.com/58242304/209519784-e5865691-f821-4d13-859b-0c70ce08c7bb.png)

### AFTER
![daftar permohonan lighhouse](https://user-images.githubusercontent.com/58242304/209519805-cd19cac6-b4a5-48aa-b0e7-d1162c91478a.png)

*accessibility not 100 % because pagespeed or lighthouse give suggestions for color styling, I think we can skip that



title: fix value accessibilty for web performance
project: Digiteam Inventaris Platform
participants: @rayfajars @yoslie @Ibwedagama @rizfirman @sheilaazhar @doohanas 